### PR TITLE
Update Version.h

### DIFF
--- a/GLTFSDK/Inc/GLTFSDK/Version.h
+++ b/GLTFSDK/Inc/GLTFSDK/Version.h
@@ -17,7 +17,7 @@ namespace Microsoft
             uint32_t major;
             uint32_t minor;
 
-            constexpr Version(uint32_t major, uint32_t minor) : major(major), minor(minor)
+            constexpr Version(uint32_t major, uint32_t minor) : major{major}, minor{minor}
             {
             }
 


### PR DESCRIPTION
Use curly braces in member initialisation. 
"major" and "minor" are macros defined by the gcc compiler. The macros are defined in sys/sysmacros.h which is getting pulled in by #include <string> 
Using curly braces stops the macro from being expanded.